### PR TITLE
feat(auth): add random password support and fallback for callback URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [v2.1] — 2026-04-27
+
+### Added
+
+- New `random_password` config option (`ZHYLON_AUTH_RANDOM_PASSWORD`, default `true`) — when enabled, a cryptographically random 32-character password is automatically hashed and assigned to newly created users.
+
+### Fixed
+
+- OAuth callback URL now falls back to `app.url` if `callback_website` is not configured or empty in `zhylon-auth.service`, preventing a broken redirect on minimal setups.
+
+---
+
 ## [v2.0] — 2026-02-26
 
 ### ⚠️ Breaking Changes

--- a/config/zhylon-auth.php
+++ b/config/zhylon-auth.php
@@ -9,5 +9,6 @@ return [
         'base_uri'         => env('ZHYLON_AUTH_BASE_URI', 'https://id.zhylon.net'),
         'home'             => env('ZHYLON_AUTH_HOME', '/dashboard'),
         'create_team'      => env('ZHYLON_AUTH_CREATE_TEAM', true),
+        'random_password'  => env('ZHYLON_AUTH_RANDOM_PASSWORD', true),
     ],
 ];

--- a/src/Controllers/ZhylonAuthController.php
+++ b/src/Controllers/ZhylonAuthController.php
@@ -5,7 +5,9 @@ namespace Zhylon\ZhylonAuth\Controllers;
 use TypeError;
 use Exception;
 use App\Models\User;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 use Laravel\Socialite\Facades\Socialite;
 use Zhylon\ZhylonAuth\Exceptions\ZhylonException;
 
@@ -40,13 +42,7 @@ class ZhylonAuthController
                 return $this->handleExistingUser($user, $zhylonUser);
             }
 
-            $createUser = User::create([
-                'zhylon_id'            => $zhylonUser->id,
-                'name'                 => $zhylonUser->name,
-                'email'                => $zhylonUser->email,
-                'zhylon_token'         => $zhylonUser->token,
-                'zhylon_refresh_token' => $zhylonUser->refreshToken,
-            ]);
+            $createUser = User::create($this->getUserData($zhylonUser));
 
             $this->createTeam($createUser);
 
@@ -103,5 +99,23 @@ class ZhylonAuthController
             'name'          => explode(' ', $user->name, 2)[0]."'s Team",
             'personal_team' => true,
         ]));
+    }
+
+    private function getUserData(
+        \Laravel\Socialite\Contracts\User $zhylonUser
+    ): array {
+        $baseData = [
+            'zhylon_id'            => $zhylonUser->id,
+            'name'                 => $zhylonUser->name,
+            'email'                => $zhylonUser->email,
+            'zhylon_token'         => $zhylonUser->token,
+            'zhylon_refresh_token' => $zhylonUser->refreshToken,
+        ];
+
+        if (config('zhylon-auth.service.random_password', true)) {
+            $baseData['password'] = Hash::make(Str::random(32));
+        }
+
+        return $baseData;
     }
 }

--- a/src/Providers/ZhylonAuthServiceProvider.php
+++ b/src/Providers/ZhylonAuthServiceProvider.php
@@ -41,7 +41,13 @@ class ZhylonAuthServiceProvider extends ServiceProvider
         $socialite = $this->app->make(Factory::class);
         $socialite->extend('zhylon', function () use ($socialite) {
             $config = config('zhylon-auth.service');
-            $config['redirect'] = $config['callback_website'].$config['site_path'].'/callback';
+
+            $website = $config['callback_website'] ?? null;
+            if (empty($website)) {
+                $website = config('app.url');
+            }
+
+            $config['redirect'] = $website.$config['site_path'].'/callback';
 
             return $socialite->buildProvider(SocialiteZhylonProvider::class, $config);
         });


### PR DESCRIPTION
- Add optional random password generation for new users via `zhylon-auth.service.random_password` config flag (default: true)
- Fall back to `app.url` if `callback_website` is not set in config

And finally added changelog
#5